### PR TITLE
Correct management of wildcard, fix #6

### DIFF
--- a/WitSync/CommandLineOptions.cs
+++ b/WitSync/CommandLineOptions.cs
@@ -11,7 +11,7 @@ namespace WitSync
     [CommandLineManager(
         ApplicationName = "WitSync",
         Copyright = "Copyright (c) Giulio Vian",
-        Version = "0.2.1.0",
+        Version = "0.2.1.1",
         EnabledOptionStyles = OptionStyles.Windows | OptionStyles.ShortUnix | OptionStyles.LongUnix)]
     public class WitSyncCommandLineOptions
     {

--- a/WitSync/Mapping_Scrum_2_Scrum_Index.xml
+++ b/WitSync/Mapping_Scrum_2_Scrum_Index.xml
@@ -4,7 +4,7 @@
   <SourceQuery>Shared Queries\MySourceQuery</SourceQuery>
   <!-- Microsoft Visual Studio Scrum -->
   <DestinationQuery>Shared Queries\MyDestinationQuery</DestinationQuery>
-  <IndexFile>index.xml</IndexFile>
+  <IndexFile>local2vso-index.xml</IndexFile>
   <AreaMap>
     <!-- map to root -->
     <Area SourcePath="*" DestinationPath=""/>
@@ -24,8 +24,6 @@
     <!-- built-in functions -->
     <Field Source="Area Path" Destination="Area Path" Translate="MapAreaPath"/>
     <Field Source="Iteration Path" Destination="Iteration Path" Translate="MapIterationPath"/>
-    <!-- must be explicit -->
-    <Field Source="Title" Destination="Title"/>
     <Field Source="*" Destination="*"/>
   </WorkItemMap>
   <WorkItemMap SourceType="Product Backlog Item" DestinationType="Product Backlog Item">
@@ -39,8 +37,6 @@
     <!-- built-in functions -->
     <Field Source="Area Path" Destination="Area Path" Translate="MapAreaPath"/>
     <Field Source="Iteration Path" Destination="Iteration Path" Translate="MapIterationPath"/>
-    <!-- must be explicit -->
-    <Field Source="Title" Destination="Title"/>
     <Field Source="*" Destination="*"/>
   </WorkItemMap>
   <WorkItemMap SourceType="Task" DestinationType="Task">
@@ -54,8 +50,6 @@
     <!-- built-in functions -->
     <Field Source="Area Path" Destination="Area Path" Translate="MapAreaPath"/>
     <Field Source="Iteration Path" Destination="Iteration Path" Translate="MapIterationPath"/>
-    <!-- must be explicit -->
-    <Field Source="Title" Destination="Title"/>
     <Field Source="*" Destination="*"/>
   </WorkItemMap>
 </Mapping>

--- a/WitSync/Properties/AssemblyInfo.cs
+++ b/WitSync/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.1")]

--- a/WitSyncEngine/Mapper.cs
+++ b/WitSyncEngine/Mapper.cs
@@ -144,12 +144,15 @@ namespace WitSync
                     eventSink.NoRuleFor(source, fromField.Name);
                     continue;
                 }
+                string targetFieldName
+                    = rule.IsWildcard
+                    ? fromField.Name : rule.Destination;
                 // good source with destination?
                 if (fromField.IsValid
                     && !string.IsNullOrWhiteSpace(rule.Destination)
-                    && target.Fields.Contains(rule.Destination))
+                    && target.Fields.Contains(targetFieldName))
                 {
-                    var toField = target.Fields[rule.Destination];
+                    var toField = target.Fields[targetFieldName];
                     if (CanAssign(fromField, toField))
                     {
                         if (rule.IsWildcard)

--- a/WitSyncEngine/Properties/AssemblyInfo.cs
+++ b/WitSyncEngine/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.1")]
 
 [assembly: InternalsVisibleTo("WitSyncEngine.Tests")]


### PR DESCRIPTION
The fix to #3 used the raw Destination value for identifying a target
field, but no field is named "*"
